### PR TITLE
Various improvements...

### DIFF
--- a/etc/packer-utils/source-images.json
+++ b/etc/packer-utils/source-images.json
@@ -1,8 +1,8 @@
 {
     "sl": 
 	{ 
-		"7x-x86_64" : "bc4118de-23fc-4cdf-8c32-cb794778d494",
-		"6x-x86_64" : "d2eea166-b643-40f5-bb7f-ca17d2f1c6fe"
+		"7x" : "0b10e583-9e13-4878-9116-f4002846fa73",
+		"6x" : "7eb100a3-680b-4544-99cc-950b8c4f6c74"
 	},
     "os": { "os_version" : "this-is-not-valid" }
 }

--- a/usr/local/bin/rabbit2packer.py
+++ b/usr/local/bin/rabbit2packer.py
@@ -3,7 +3,7 @@ import sys
 import pika
 from syslog import syslog, LOG_ERR, LOG_INFO
 from configparser import SafeConfigParser
-import subprocess  
+import subprocess
 import threading
 import time
 import json
@@ -34,7 +34,7 @@ except Exception as e:
     sys.exit(1)
 
 try:
-    with open(IMAGES_CONFIG) as images_JSON:    
+    with open(IMAGES_CONFIG) as images_JSON:
         IMAGES = json.load(images_JSON)
 except IOError as e:
     syslog(LOG_ERR, repr(e))
@@ -46,7 +46,7 @@ except ValueError as e:
     sys.exit(1)
 
 try:
-    with open(PACKER_TEMPLATE_MAP) as template_map_JSON:    
+    with open(PACKER_TEMPLATE_MAP) as template_map_JSON:
         TEMPLATE_MAP = json.load(template_map_JSON)
 except IOError as e:
     syslog(LOG_ERR, repr(e))
@@ -64,22 +64,15 @@ exitFlag = 0
 class imageBuilder:
     def __init__(self, profile_object):
         self.personality = profile_object["system"]["personality"]["name"]
-        self.os_string = profile_object["system"]["aii"]["nbp"]["pxelinux"]["kernel"].split('/')[0]
-        self.os = ""
-        self.os_ver = ""
-        for os in IMAGES:
-            if self.os_string.startswith(os):
-                for ver in IMAGES[os]:
-                    if self.os_string == os + ver:
-                        self.os = os
-                        self.os_ver = ver
-                        self.imageID = IMAGES[self.os][self.os_ver]
-        if not (self.os and self.os_ver):
-            raise KeyError('os and os_ver not found in the source image dict')
+        self.os = profile_object["system"]["os"]["distribution"]["name"]
+        self.os_ver = profile_object["system"]["os"]["version"]["name"]
+        self.imageID = IMAGES[self.os][self.os_ver]
+        if not (self.imageID):
+            raise KeyError('source image not found in dict for os %s and os_ver %s' % self.os, self.os_ver)
     def name(self):
-        return "%s-%s" % (self.personality, self.os_string)
+        return "%s-%s%s" % (self.personality, self.os, self.os_ver)
     def prettyName(self):
-        return "%s %s" % (self.os_string, self.personality)
+        return "%s%s %s" % (self.os, self.os_ver, self.personality)
     def imageID(self):
         return self.imageID
     def metadata(self):
@@ -106,7 +99,7 @@ class workerThread (threading.Thread):
 
         channel = connection.channel()
         channel.queue_declare(
-            queue=QUEUE, 
+            queue=QUEUE,
             durable=True
         )
 
@@ -149,11 +142,11 @@ def worker_loop(threadName, channel):
                 image = imageBuilder(profile_object)
             except KeyError as e:
                 syslog(LOG_ERR, repr(e))
-                syslog(LOG_ERR, threadName + ": source imge was not found, check IMAGES_CONFIG. Continuing")
+                syslog(LOG_ERR, threadName + ": source image was not found, check IMAGES_CONFIG. Continuing")
                 continue
             syslog(LOG_ERR, "%s processing %s" % (threadName, image.name()))
             run_packer_subprocess(threadName, image)
-            
+
         time.sleep(2)
 
 
@@ -162,7 +155,7 @@ def run_packer_subprocess(threadName, image):
     image_name=image.name()
     image_display_name=image.prettyName()
     image_metadata=image.metadata()
-        
+
     try:
         source_image_ID = image.imageID
     except KeyError as e:
@@ -172,11 +165,11 @@ def run_packer_subprocess(threadName, image):
 
     templates = TEMPLATE_MAP.get(image_name)
 
-    if templates is None:        
+    if templates is None:
         templates = TEMPLATE_MAP.get("DEFAULT")
         syslog(LOG_INFO, "No Packer template defined for " + image_name + ". Using the default values")
 
-    if templates is None:        
+    if templates is None:
         syslog(LOG_INFO, "No Packer template defined for Default values. No builds will occur.")
 
     for template in templates:
@@ -223,13 +216,13 @@ def run_packer_subprocess(threadName, image):
             syslog(LOG_ERR, "Unable to write to build log file: %s" %  log_file_path )
             syslog(LOG_ERR, repr(e))
             sys.exit(1)
-        
+
         packerCmd = ( "source {packer_auth};"
                       "export OS_TENANT_ID=$OS_PROJECT_ID;"
-                      "export OS_DOMAIN_NAME=$OS_USER_DOMAIN_NAME;"  
-                      "packer.io build {build_file}"
+                      "export OS_DOMAIN_NAME=$OS_USER_DOMAIN_NAME;"
+                      "packer.io build {build_file};"
                     ).format(
-                        packer_auth=PACKER_AUTH_FILE, 
+                        packer_auth=PACKER_AUTH_FILE,
                         build_file=build_file_path
                     )
 

--- a/usr/local/bin/rabbit2packer.py
+++ b/usr/local/bin/rabbit2packer.py
@@ -206,14 +206,15 @@ def run_packer_subprocess(threadName, image):
 
 
         build_file_path=BUILD_FILE_DIR + '/' + image_name + "." + template_name + ".json"
-        log_file_path=LOG_DIR + '/' + image_name + "." + template_name + ".log"
+        build_start_time = int(time.time())
+        log_file_path=LOG_DIR + '/' + image_name + "." + template_name + "." + repr(build_start_time) + ".log"
 
         try:
             with open( build_file_path, "wt") as buildFile:
                 buildFile.write(template)
         except IOError as e:
             syslog(LOG_ERR, "Unable to write build file: %s" %  build_file_path )
-            syslog(LOG_ERR, repr(e))        
+            syslog(LOG_ERR, repr(e))
             sys.exit(1)
 
         try:
@@ -236,6 +237,8 @@ def run_packer_subprocess(threadName, image):
 
         packerProc = subprocess.Popen(packerCmd, shell=True, stdout=buildLog, stderr=subprocess.STDOUT)
         ret_code = packerProc.wait()
+        build_finish_time = int(time.time())
+        buildLog.write("rabbit2packer: Build finished at %s (epoch) with exit code %s\n" % (build_finish_time, ret_code))
         if (ret_code != 0):
             syslog(LOG_ERR, threadName + ": packer exited with non zero exit code, " + image_name + "." + template_name+ " build failed")
         else:
@@ -251,10 +254,3 @@ for i in range(THREAD_COUNT):
 
 while True:
     time.sleep(5)
-
-
-
-
-
-
-


### PR DESCRIPTION
#### 1. Add information to logs for packuilon-monitor.

   Log filenames now contain an epoch timestamp of the start time of the build,
which should help to order builds chronologically and keep old logs around -- as well as keeping the
monitor stateless.

A final line is also added to individual build logs:

    rabbit2packer: Build finished at <<time>> (epoch) with exit code <<code>>

This will allow the monitor to know
     1. whether the build is still running, and
     2. if it's finished, how long it took and if it passed or failed.

#### 2. Change OS mapping logic to use new quattor datastructure. [Tom's changes]

Quattor profiles now contain canonical metadata of the OS and OS version. `rabbit2packer` now uses these to map source images, cleaning up that section.
