### PR TITLE
 Changed source image map layout and added updated instance metadata 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,13 @@ The template file to be used is defined in `PACKER_TEMPLATE_MAP` (`/etc/packer-u
 If the image has an entry (such as test-sl7x above) then that template will be used, otherwise the `DEFAULT` entry will be used. Multiple templates can be defined and they will all be built (currently one after another). Defining an entry prevents the default template(s) being built for that host.
 
 
-The source image for each operating system type is defined in a separate config file defined in the main config.ini (`/etc/packer-utils/source-images.json` by default). The file contains key value pair structure, with the key being the OS, the sub-key being the OS_VERSION, and the value of that subkey being the image ID to use. For example:
+The source image for each operating system type is defined in a separate config file defined in the main config.ini (`/etc/packer-utils/source-images.json` by default). The file contains key value pair structure, with the key being the `os+os_version-arch` string, and the value being the image ID to use. For example:
 
 ```
 {
-    "sl": 
-	{ 
-		"7x" : "bc4118de-23fc-4cdf-8c32-cb794778d494",
-		"6x" : "d2eea166-b643-40f5-bb7f-ca17d2f1c6fe"
-	},
-    "os": { "os_version" : "image uuid" }
+    "sl6x-x86_64" : "7eb100a3-680b-4544-99cc-950b8c4f6c74",
+    "sl7x-x86_64" : "0b10e583-9e13-4878-9116-f4002846fa73",
+    "osos_version-archetype" : "this-is-not-valid"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of scripts to allow OpenStack VM images to be automatically built b
 
 Checks for changes to the continuous integration profiles (or profiles defined by a "PROFILE_MATCH" string, which can be left blank for all profiles), and pushes a message to a RabbitMQ queue. Can be called by cron, or by quattor (using ncm-cdispd). The message is just the profile object (json encoded).
 
-#rabbit2packer
+# rabbit2packer
 
 Listens to the RabbitMQ queue. When one is received it creates a packer build file and starts the packer process.
 
@@ -35,8 +35,8 @@ The source image for each operating system type is defined in a separate config 
 {
     "sl": 
 	{ 
-		"7x-x86_64" : "bc4118de-23fc-4cdf-8c32-cb794778d494",
-		"6x-x86_64" : "d2eea166-b643-40f5-bb7f-ca17d2f1c6fe"
+		"7x" : "bc4118de-23fc-4cdf-8c32-cb794778d494",
+		"6x" : "d2eea166-b643-40f5-bb7f-ca17d2f1c6fe"
 	},
     "os": { "os_version" : "image uuid" }
 }
@@ -50,7 +50,7 @@ The packer shell provisioned then runs a fetch+configure with the new profile vi
 
 This process is logged in separate log for each build, found in the `LOG_DIR`. Bear in mind that these are overwritten when a new build of that image starts, so there are no historical build logs kept. This is a area for improvement if anyone is bored.
 
-#Installation
+# Installation
 
 *this is mostly SCD specific*
 

--- a/etc/packer-utils/source-images.json
+++ b/etc/packer-utils/source-images.json
@@ -1,8 +1,5 @@
 {
-    "sl": 
-	{ 
-		"7x" : "0b10e583-9e13-4878-9116-f4002846fa73",
-		"6x" : "7eb100a3-680b-4544-99cc-950b8c4f6c74"
-	},
-    "os": { "os_version" : "this-is-not-valid" }
+    "sl6x-x86_64" : "7eb100a3-680b-4544-99cc-950b8c4f6c74",
+    "sl7x-x86_64" : "0b10e583-9e13-4878-9116-f4002846fa73",
+    "osos_version-archetype" : "this-is-not-valid"
 }

--- a/usr/local/bin/rabbit2packer.py
+++ b/usr/local/bin/rabbit2packer.py
@@ -64,21 +64,34 @@ exitFlag = 0
 class imageBuilder:
     def __init__(self, profile_object):
         self.personality = profile_object["system"]["personality"]["name"]
+        if not (self.personality):
+            raise KeyError('personality value not found in profile, cannot continue build')
+        self.archetype = profile_object["system"]["archetype"]["name"]
+        if not (self.archetype):
+            raise KeyError('archetype value not found in profile, cannot continue build')
+        self.architecture = profile_object["system"]["os"]["architecture"]
+        if not (self.architecture):
+            raise KeyError(' architecture value not found in profile, cannot continue build')
         self.os = profile_object["system"]["os"]["distribution"]["name"]
+        if not (self.os):
+            raise KeyError('OS value not found in profile, cannot continue build')
         self.os_ver = profile_object["system"]["os"]["version"]["name"]
-        self.imageID = IMAGES[self.os][self.os_ver]
+        if not (self.personality):
+            raise KeyError('os_ver value not found in profile, cannot continue build')
+        self.imageID = IMAGES["%s%s-%s" % (self.os, self.os_ver, self.architecture)]
         if not (self.imageID):
-            raise KeyError('source image not found in dict for os %s and os_ver %s' % self.os, self.os_ver)
+            raise KeyError('source image not found in dict for key %s%s-%s' % self.os, self.os_ver, self.architecture)
     def name(self):
-        return "%s-%s%s" % (self.personality, self.os, self.os_ver)
+        return "%s-%s%s-%s" % (self.personality, self.os, self.os_ver, self.architecture)
     def prettyName(self):
-        return "%s%s %s" % (self.os, self.os_ver, self.personality)
+        return "%s%s-%s %s" % (self.os, self.os_ver, self.architecture, self.personality)
     def imageID(self):
         return self.imageID
     def metadata(self):
         self.metadata = '"AQ_PERSONALITY": "%s",\n' % self.personality
         self.metadata += '"AQ_OS": "%s",\n' % self.os
-        self.metadata += '"AQ_OSVERSION": "%s"\n' % self.os_ver
+        self.metadata += '"AQ_OSVERSION": "%s-%s",\n' % (self.os_ver, self.architecture)
+        self.metadata += '"AQ_DOMAIN": "prod"\n'
         return self.metadata
 
 class workerThread (threading.Thread):


### PR DESCRIPTION
The original layout was complicated due to the issues with getting the os and os_ver from the profile. the new method (see pull #1) simplifies this, and so I've reduced the complexity in the image map now.

I've also pulled some more metadata from the profile to be passed into the packer build template, this is due to the aquilon hook scripts no longer defaulting to values, and so I've had to implement that as well.

I've also updated the readme to reflect this, and made some minor formatting fixes.